### PR TITLE
Update PrjSvr 2016 system requirements for Windows Server 2019

### DIFF
--- a/Project/software-requirements-for-project-server-2016.md
+++ b/Project/software-requirements-for-project-server-2016.md
@@ -33,9 +33,9 @@ Some of the key software requirements for SharePoint Server 2016 are:
   
 |||
 |:-----|:-----|
-|**Supported Server Operating Systems** **:** <br/> | Windows Server 2016 Standard or Datacenter <br/>  Windows Server 2012 R2 <br/> |
-|**Supported Database Server** **:** <br/> | Microsoft SQL Server 2017 RTM for Windows <br/> Microsoft SQL Server 2016 RTM <br/>  The 64-bit edition of SQL Server 2014 with Service Pack 1 (SP1) <br/>  SQL Analysis Services must also be installed if you are using the Cube Building Service in Project Server 2016. <br/> |
-|**Supported browsers** **:** <br/> | Microsoft Edge <br/>  Microsoft Internet Explorer 11 <br/>  Microsoft Internet Explorer 10 <br/>  Google Chrome (latest released version) <br/>  Mozilla Firefox (latest released version plus immediate previous version) <br/>  Apple Safari (latest released version) <br/> |
+|**Supported Server Operating Systems** **:** <br/> | Windows Server 2019 Standard or Datacenter <br/> Windows Server 2016 Standard or Datacenter <br/> Windows Server 2012 R2 <br/> |
+|**Supported Database Server** **:** <br/> | Microsoft SQL Server 2017 RTM for Windows <br/> Microsoft SQL Server 2016 RTM <br/> The 64-bit edition of SQL Server 2014 with Service Pack 1 (SP1) <br/> SQL Analysis Services must also be installed if you are using the Cube Building Service in Project Server 2016. <br/> |
+|**Supported browsers** **:** <br/> | Microsoft Edge <br/> Microsoft Internet Explorer 11 <br/> Microsoft Internet Explorer 10 <br/> Google Chrome (latest released version) <br/> Mozilla Firefox (latest released version plus immediate previous version) <br/> Apple Safari (latest released version) <br/> |
    
 > [!NOTE]
 > For information about the hardware, software, and browser requirement for SharePoint Server 2016, see [System requirements for SharePoint Server 2016 IT Preview](http://technet.microsoft.com/library/64233599-f18c-4081-a3ce-450e878a1b9f.aspx). 


### PR DESCRIPTION
Update Project Server 2016 system requirements to add Windows Server 2019 as a supported operating system.