### PR TITLE
Parameter 'OwnerAlias' added to New-SPSite command

### DIFF
--- a/Project/deploy-project-web-app-with-a-new-site-collection-project-server-2016.md
+++ b/Project/deploy-project-web-app-with-a-new-site-collection-project-server-2016.md
@@ -100,14 +100,14 @@ Verify that you have the following memberships:
 From the PowerShell command prompt, run the following commands to create the Project Web App site.
 
 ```
-New-SPSite -ContentDatabase ContentDBName -URL SiteCollectionURL/PWASiteName -Template pwa#0
+New-SPSite -ContentDatabase ContentDBName -URL SiteCollectionURL/PWASiteName -Template pwa#0 -OwnerAlias domain\user
 Enable-SPFeature pwasite -URL SiteCollectionURL/PWASiteName
 ```
 
 For example:
 
 ```
-New-SPSite -ContentDatabase PWA_Content -URL http://contoso-appsrv1/sites/PWA -Template pwa#0
+New-SPSite -ContentDatabase PWA_Content -URL http://contoso-appsrv1/sites/PWA -Template pwa#0 -OwnerAlias domain\user
 Enable-SPFeature pwasite -URL http://contoso-appsrv1/sites/PWA
 ```
 


### PR DESCRIPTION
The command `New-SPSite` was missing the parameter `-OwnerAlias` to create a new site collection.
I created the issue #22 