### PR TITLE
Update office-365-user-view-access-to-project-and-roadmap.md

### DIFF
--- a/ProjectWeb/office-365-user-view-access-to-project-and-roadmap.md
+++ b/ProjectWeb/office-365-user-view-access-to-project-and-roadmap.md
@@ -35,7 +35,7 @@ Office 365 view access applies to the following families of Office 365 suites an
 Within each subscription, there are two apps that can be seen from the Microsoft 365 Admin center.
 
 - Project for Office (Plan X)
-- Dataverse
+- Common Data Service
 
 The "Plan" in the title of Project for Office comes from the family of suite the app is included in. Both apps (from the same subscription) must be assigned to the user to view Project for the web or Roadmap.
 


### PR DESCRIPTION
"Dataverse" term is not being used in admin center, which causes confusion. The name should be reverted back to "Common Data Service". Confirmed this for E3 and E5.